### PR TITLE
feat: Add profile image management and display for service providers

### DIFF
--- a/src/app/admin/inicio/page.tsx
+++ b/src/app/admin/inicio/page.tsx
@@ -46,9 +46,18 @@ export default function AdminInicio() {
     const now = new Date();
     const start = new Date(now.getFullYear(), now.getMonth(), 1);
     const end = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59);
+
+    // Usar formato local YYYY-MM-DD en lugar de ISO string para evitar problemas de timezone
+    const formatLocalDate = (date: Date): string => {
+      const year = date.getFullYear();
+      const month = String(date.getMonth() + 1).padStart(2, '0');
+      const day = String(date.getDate()).padStart(2, '0');
+      return `${year}-${month}-${day}`;
+    };
+
     return {
-      startDate: start.toISOString(),
-      endDate: end.toISOString(),
+      startDate: formatLocalDate(start),
+      endDate: formatLocalDate(end),
     };
   }, []);
 
@@ -155,7 +164,9 @@ export default function AdminInicio() {
           appointment.status === "completada",
       )
       .reduce((acc, appointment) => {
-        return acc + (appointment.service?.price ?? 0);
+        const price = appointment.service?.price ?? 0;
+        const numericPrice = typeof price === 'string' ? parseFloat(price) : price;
+        return acc + (isNaN(numericPrice) ? 0 : numericPrice);
       }, 0);
   }, [data.appointments]);
 

--- a/src/app/admin/personal/page.tsx
+++ b/src/app/admin/personal/page.tsx
@@ -15,6 +15,7 @@ import { useToast } from "@/providers/ToastProvider";
 import type { ProviderType, User } from "@/types/user";
 import {
   FaCheckCircle,
+  FaEdit,
   FaEnvelope,
   FaPhoneAlt,
   FaPlus,
@@ -204,20 +205,37 @@ export default function AdminPersonalSalon() {
               className="flex h-full flex-col gap-4 rounded-3xl border border-white/10 bg-slate-900/60 p-6 shadow-xl transition hover:border-pink-400/50"
             >
               <div className="flex items-start justify-between gap-3">
-                <div>
-                  <p className="text-xs uppercase tracking-[0.3em] text-white/50">
-                    {user.providerType
-                      ? user.providerType.replace("_", " ")
-                      : user.role === "admin"
-                        ? "Administrador"
-                        : "Equipo"}
-                  </p>
-                  <h3 className="mt-1 text-xl font-semibold text-white">
-                    {user.fullName?.trim() ||
-                      `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() ||
-                      user.email}
-                  </h3>
-                  <p className="text-xs text-gray-400">{user.email}</p>
+                <div className="flex items-start gap-3">
+                  {user.profileImage ? (
+                    <div className="h-16 w-16 flex-shrink-0 overflow-hidden rounded-xl border-2 border-pink-400/30">
+                      <img
+                        src={user.profileImage}
+                        alt={user.fullName || user.email}
+                        className="h-full w-full object-cover"
+                      />
+                    </div>
+                  ) : (
+                    <div className="flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-xl border-2 border-white/10 bg-gradient-to-br from-pink-500/20 to-orange-400/20">
+                      <span className="text-2xl font-bold text-white">
+                        {(user.firstName?.[0] || user.email[0]).toUpperCase()}
+                      </span>
+                    </div>
+                  )}
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.3em] text-white/50">
+                      {user.providerType
+                        ? user.providerType.replace("_", " ")
+                        : user.role === "admin"
+                          ? "Administrador"
+                          : "Equipo"}
+                    </p>
+                    <h3 className="mt-1 text-xl font-semibold text-white">
+                      {user.fullName?.trim() ||
+                        `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() ||
+                        user.email}
+                    </h3>
+                    <p className="text-xs text-gray-400">{user.email}</p>
+                  </div>
                 </div>
                 <span
                   className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${
@@ -249,6 +267,13 @@ export default function AdminPersonalSalon() {
               </div>
 
               <div className="mt-auto flex flex-wrap gap-3 text-sm">
+                <Link
+                  href={`/admin/personal/${user.id}/editar`}
+                  className="inline-flex items-center justify-center gap-2 rounded-full border border-pink-400/40 px-4 py-2 font-semibold text-pink-200 transition hover:border-pink-400/60 hover:text-pink-100"
+                >
+                  <FaEdit className="text-xs" />
+                  Editar
+                </Link>
                 <button
                   type="button"
                   onClick={() => setTargetUser(user)}

--- a/src/app/mis-citas/page.tsx
+++ b/src/app/mis-citas/page.tsx
@@ -298,18 +298,35 @@ export default function MisCitas() {
                           className="rounded-3xl border border-white/10 bg-slate-900/70 p-6 shadow-xl transition hover:border-pink-400/50"
                         >
                           <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-                            <div>
-                              <h3 className="text-lg font-semibold text-white">
-                                {appointment.service?.name ?? "Servicio"}
-                              </h3>
-                              <p className="mt-1 text-sm text-gray-300">
-                                {formatAppointmentDate(appointment.date, appointment.startTime)}
-                              </p>
-                              <p className="mt-1 text-xs uppercase tracking-wider text-gray-400">
-                                {appointment.service?.provider?.fullName
-                                  ? `Con ${appointment.service.provider.fullName}`
-                                  : "Personal asignado"}
-                              </p>
+                            <div className="flex gap-3">
+                              {appointment.service?.provider?.profileImage ? (
+                                <div className="h-14 w-14 flex-shrink-0 overflow-hidden rounded-xl border-2 border-pink-400/30">
+                                  <img
+                                    src={appointment.service.provider.profileImage}
+                                    alt={appointment.service.provider.fullName || "Prestador"}
+                                    className="h-full w-full object-cover"
+                                  />
+                                </div>
+                              ) : appointment.service?.provider ? (
+                                <div className="flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-xl border-2 border-white/10 bg-gradient-to-br from-pink-500/20 to-orange-400/20">
+                                  <span className="text-lg font-bold text-white">
+                                    {appointment.service.provider.firstName?.[0]?.toUpperCase() || "?"}
+                                  </span>
+                                </div>
+                              ) : null}
+                              <div>
+                                <h3 className="text-lg font-semibold text-white">
+                                  {appointment.service?.name ?? "Servicio"}
+                                </h3>
+                                <p className="mt-1 text-sm text-gray-300">
+                                  {formatAppointmentDate(appointment.date, appointment.startTime)}
+                                </p>
+                                <p className="mt-1 text-xs uppercase tracking-wider text-gray-400">
+                                  {appointment.service?.provider?.fullName
+                                    ? `Con ${appointment.service.provider.fullName}`
+                                    : "Personal asignado"}
+                                </p>
+                              </div>
                             </div>
                             <span
                               className={`inline-flex h-9 items-center rounded-full border px-4 text-xs font-semibold uppercase tracking-wider ${STATUS_STYLES[appointment.status]}`}
@@ -377,18 +394,35 @@ export default function MisCitas() {
                           className="rounded-3xl border border-white/10 bg-slate-900/60 p-5 text-sm text-gray-200"
                         >
                           <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                            <div>
-                              <h3 className="text-base font-semibold text-white">
-                                {appointment.service?.name ?? "Servicio"}
-                              </h3>
-                              <p className="text-xs uppercase tracking-wider text-gray-400">
-                                {formatAppointmentDate(appointment.date, appointment.startTime)}
-                              </p>
-                              {appointment.cancellationReason && (
-                                <p className="mt-2 text-xs text-red-200">
-                                  Motivo de cancelacion: {appointment.cancellationReason}
+                            <div className="flex gap-3">
+                              {appointment.service?.provider?.profileImage ? (
+                                <div className="h-12 w-12 flex-shrink-0 overflow-hidden rounded-lg border border-pink-400/30">
+                                  <img
+                                    src={appointment.service.provider.profileImage}
+                                    alt={appointment.service.provider.fullName || "Prestador"}
+                                    className="h-full w-full object-cover"
+                                  />
+                                </div>
+                              ) : appointment.service?.provider ? (
+                                <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-lg border border-white/10 bg-gradient-to-br from-pink-500/20 to-orange-400/20">
+                                  <span className="text-sm font-bold text-white">
+                                    {appointment.service.provider.firstName?.[0]?.toUpperCase() || "?"}
+                                  </span>
+                                </div>
+                              ) : null}
+                              <div>
+                                <h3 className="text-base font-semibold text-white">
+                                  {appointment.service?.name ?? "Servicio"}
+                                </h3>
+                                <p className="text-xs uppercase tracking-wider text-gray-400">
+                                  {formatAppointmentDate(appointment.date, appointment.startTime)}
                                 </p>
-                              )}
+                                {appointment.cancellationReason && (
+                                  <p className="mt-2 text-xs text-red-200">
+                                    Motivo de cancelacion: {appointment.cancellationReason}
+                                  </p>
+                                )}
+                              </div>
                             </div>
                             <span
                               className={`inline-flex h-8 items-center rounded-full border px-3 text-[0.65rem] font-semibold uppercase tracking-wider ${STATUS_STYLES[appointment.status]}`}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -350,10 +350,27 @@ function ServicesSection({
                     <span className="rounded-full border border-white/10 px-3 py-1">
                       Duracion {service.durationMinutes} min
                     </span>
-                    {service.provider?.fullName && (
-                      <span className="rounded-full border border-white/10 px-3 py-1">
-                        {service.provider.fullName}
-                      </span>
+                    {service.provider && (
+                      <div className="ml-auto flex items-center gap-2">
+                        {service.provider.profileImage ? (
+                          <div className="h-6 w-6 flex-shrink-0 overflow-hidden rounded-full border border-pink-400/30">
+                            <img
+                              src={service.provider.profileImage}
+                              alt={service.provider.fullName || "Prestador"}
+                              className="h-full w-full object-cover"
+                            />
+                          </div>
+                        ) : (
+                          <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full border border-white/20 bg-gradient-to-br from-pink-500/20 to-orange-400/20">
+                            <span className="text-[0.6rem] font-bold text-white">
+                              {service.provider.firstName?.[0]?.toUpperCase() || "?"}
+                            </span>
+                          </div>
+                        )}
+                        <span className="text-xs text-gray-300">
+                          {service.provider.fullName}
+                        </span>
+                      </div>
                     )}
                   </div>
                   <div className="flex flex-wrap items-center justify-between gap-3 pt-2">

--- a/src/app/personal-salon/page.tsx
+++ b/src/app/personal-salon/page.tsx
@@ -135,9 +135,19 @@ export default function PersonalSalon() {
                     className="rounded-3xl border border-white/10 bg-slate-900/70 p-6 shadow-xl transition hover:border-pink-400/50 hover:shadow-pink-500/20"
                   >
                     <div className="flex items-center gap-4">
-                      <div className="flex h-16 w-16 items-center justify-center rounded-2xl border border-white/10 bg-white/5">
-                        {meta?.icon ?? <FaUserTie className="text-3xl text-pink-400" />}
-                      </div>
+                      {provider.profileImage ? (
+                        <div className="h-16 w-16 flex-shrink-0 overflow-hidden rounded-2xl border-2 border-pink-400/30 shadow-lg">
+                          <img
+                            src={provider.profileImage}
+                            alt={provider.fullName || `${provider.firstName} ${provider.lastName}`}
+                            className="h-full w-full object-cover"
+                          />
+                        </div>
+                      ) : (
+                        <div className="flex h-16 w-16 items-center justify-center rounded-2xl border border-white/10 bg-white/5">
+                          {meta?.icon ?? <FaUserTie className="text-3xl text-pink-400" />}
+                        </div>
+                      )}
                       <div>
                         <h2 className="text-xl font-semibold text-white">
                           {provider.fullName || `${provider.firstName} ${provider.lastName}`}

--- a/src/app/prestador/horarios/page.tsx
+++ b/src/app/prestador/horarios/page.tsx
@@ -56,9 +56,15 @@ export default function PrestadorHorarios() {
   const [slots, setSlots] = useState<ServiceSlot[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
-  const [selectedDate, setSelectedDate] = useState(
-    new Date().toISOString().split("T")[0]
-  );
+  // Función para obtener fecha local en formato YYYY-MM-DD sin conversión a UTC
+  const getLocalDateString = (date: Date = new Date()): string => {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  };
+
+  const [selectedDate, setSelectedDate] = useState(getLocalDateString());
   const [viewMode, setViewMode] = useState<"dia" | "semana" | "mes">("dia");
   const [showGenerateModal, setShowGenerateModal] = useState(false);
   const [generating, setGenerating] = useState(false);
@@ -66,7 +72,7 @@ export default function PrestadorHorarios() {
 
   const [form, setForm] = useState({
     serviceId: "",
-    date: new Date().toISOString().split("T")[0],
+    date: getLocalDateString(),
     startTime: "09:00",
     endTime: "18:00",
     durationMinutes: "",

--- a/src/app/reservar/page.tsx
+++ b/src/app/reservar/page.tsx
@@ -353,12 +353,31 @@ export default function ReservarPage() {
                           <p className="mt-2 line-clamp-3 text-xs text-gray-300">
                             {service.description}
                           </p>
-                          <div className="mt-3 flex flex-wrap gap-2 text-[0.7rem] uppercase tracking-wider text-gray-400">
-                            <span>{service.durationMinutes} min</span>
-                            {service.provider?.fullName && (
-                              <span className="rounded-full border border-white/20 px-2 py-1">
-                                {service.provider.fullName}
-                              </span>
+                          <div className="mt-3 flex items-center gap-3">
+                            <div className="flex flex-wrap gap-2 text-[0.7rem] uppercase tracking-wider text-gray-400">
+                              <span>{service.durationMinutes} min</span>
+                            </div>
+                            {service.provider && (
+                              <div className="ml-auto flex items-center gap-2">
+                                {service.provider.profileImage ? (
+                                  <div className="h-8 w-8 flex-shrink-0 overflow-hidden rounded-full border border-pink-400/30">
+                                    <img
+                                      src={service.provider.profileImage}
+                                      alt={service.provider.fullName || "Prestador"}
+                                      className="h-full w-full object-cover"
+                                    />
+                                  </div>
+                                ) : (
+                                  <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full border border-white/20 bg-gradient-to-br from-pink-500/20 to-orange-400/20">
+                                    <span className="text-xs font-bold text-white">
+                                      {service.provider.firstName?.[0]?.toUpperCase() || service.provider.email?.[0]?.toUpperCase() || "?"}
+                                    </span>
+                                  </div>
+                                )}
+                                <span className="text-xs text-gray-300">
+                                  {service.provider.fullName}
+                                </span>
+                              </div>
                             )}
                           </div>
                         </button>

--- a/src/app/users/create/page.tsx
+++ b/src/app/users/create/page.tsx
@@ -4,10 +4,12 @@ import { useState } from "react";
 import { createUser } from "@/service/userService";
 import { getErrorMessage } from "@/utils/error";
 import type { UserRole } from "@/types/user";
+import PasswordRequirements, { usePasswordValidation } from "@/components/ui/PasswordRequirements";
 
 interface CreateUserForm {
   email: string;
   password: string;
+  confirmPassword: string;
   firstName: string;
   lastName: string;
   phone: string;
@@ -18,6 +20,7 @@ export default function CreateUserPage() {
   const [form, setForm] = useState<CreateUserForm>({
     email: "",
     password: "",
+    confirmPassword: "",
     firstName: "",
     lastName: "",
     phone: "",
@@ -26,6 +29,8 @@ export default function CreateUserPage() {
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
+  const { isValid: isPasswordValid } = usePasswordValidation(form.password);
+  const { isValid: isConfirmPasswordValid } = usePasswordValidation(form.confirmPassword);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { name, value } = event.target;
@@ -41,12 +46,37 @@ export default function CreateUserPage() {
     setMessage("");
     setError("");
 
+    // Validar que la contraseña cumpla con los requisitos
+    if (!isPasswordValid) {
+      setError("La contraseña no cumple con los requisitos de complejidad");
+      setLoading(false);
+      return;
+    }
+
+    // Validar que la confirmación también cumpla con los requisitos
+    if (!isConfirmPasswordValid) {
+      setError("La confirmación de contraseña no cumple con los requisitos de complejidad");
+      setLoading(false);
+      return;
+    }
+
+    // Validar que las contraseñas coincidan
+    if (form.password !== form.confirmPassword) {
+      setError("Las contraseñas no coinciden");
+      setLoading(false);
+      return;
+    }
+
     try {
-      const newUser = await createUser(form);
+      // Enviar solo los campos necesarios (sin confirmPassword)
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { confirmPassword, ...userData } = form;
+      const newUser = await createUser(userData);
       setMessage(`Usuario ${newUser.fullName} creado exitosamente.`);
       setForm({
         email: "",
         password: "",
+        confirmPassword: "",
         firstName: "",
         lastName: "",
         phone: "",
@@ -101,6 +131,47 @@ export default function CreateUserPage() {
             required
             className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-purple-600"
           />
+
+          {form.password && (
+            <div className="my-4">
+              <PasswordRequirements password={form.password} className="bg-purple-50 border-purple-200" />
+            </div>
+          )}
+
+          <input
+            type="password"
+            name="confirmPassword"
+            placeholder="Confirmar contraseña"
+            value={form.confirmPassword}
+            onChange={handleChange}
+            required
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-purple-600"
+          />
+
+          {form.confirmPassword && (
+            <div className="space-y-3">
+              <PasswordRequirements password={form.confirmPassword} className="bg-purple-50 border-purple-200" />
+              {form.password && form.confirmPassword && (
+                <div
+                  className={`flex items-center gap-2 rounded-xl border px-4 py-3 text-sm ${
+                    form.password === form.confirmPassword
+                      ? "border-emerald-400 bg-emerald-50 text-emerald-700"
+                      : "border-orange-400 bg-orange-50 text-orange-700"
+                  }`}
+                >
+                  <span className="text-lg">
+                    {form.password === form.confirmPassword ? "✓" : "✗"}
+                  </span>
+                  <span>
+                    {form.password === form.confirmPassword
+                      ? "Las contraseñas coinciden"
+                      : "Las contraseñas no coinciden"}
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
+
           <input
             name="phone"
             placeholder="Teléfono"
@@ -121,8 +192,8 @@ export default function CreateUserPage() {
 
           <button
             type="submit"
-            disabled={loading}
-            className="w-full bg-pink-600 text-white py-3 rounded-full hover:bg-pink-500 transition-colors font-semibold"
+            disabled={loading || !isPasswordValid || !isConfirmPasswordValid || form.password !== form.confirmPassword}
+            className="w-full bg-pink-600 text-white py-3 rounded-full hover:bg-pink-500 transition-colors font-semibold disabled:opacity-60 disabled:cursor-not-allowed"
           >
             {loading ? "Creando..." : "Crear Usuario"}
           </button>

--- a/src/components/ui/PasswordRequirements.tsx
+++ b/src/components/ui/PasswordRequirements.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useMemo } from "react";
+
+interface PasswordRequirement {
+  label: string;
+  regex: RegExp;
+  met: boolean;
+}
+
+interface PasswordRequirementsProps {
+  password: string;
+  className?: string;
+}
+
+export default function PasswordRequirements({
+  password,
+  className = "",
+}: PasswordRequirementsProps) {
+  const requirements: PasswordRequirement[] = useMemo(
+    () => [
+      {
+        label: "Mínimo 8 caracteres",
+        regex: /.{8,}/,
+        met: /.{8,}/.test(password),
+      },
+      {
+        label: "Al menos una letra minúscula (a-z)",
+        regex: /[a-z]/,
+        met: /[a-z]/.test(password),
+      },
+      {
+        label: "Al menos una letra mayúscula (A-Z)",
+        regex: /[A-Z]/,
+        met: /[A-Z]/.test(password),
+      },
+      {
+        label: "Al menos un número (0-9)",
+        regex: /\d/,
+        met: /\d/.test(password),
+      },
+      {
+        label: "Al menos un carácter especial (@$!%*?&)",
+        regex: /[@$!%*?&]/,
+        met: /[@$!%*?&]/.test(password),
+      },
+    ],
+    [password]
+  );
+
+  const allRequirementsMet = useMemo(
+    () => requirements.every((req) => req.met),
+    [requirements]
+  );
+
+  return (
+    <div
+      className={`space-y-3 rounded-xl border border-white/10 bg-slate-950/40 p-4 ${className}`}
+    >
+      <div className="flex items-center gap-2">
+        <div
+          className={`h-2 w-2 rounded-full transition-colors ${
+            allRequirementsMet ? "bg-emerald-400" : "bg-orange-400"
+          }`}
+        />
+        <p className="text-xs font-medium uppercase tracking-wider text-white/70">
+          Requisitos de contraseña
+        </p>
+      </div>
+
+      <ul className="space-y-2">
+        {requirements.map((requirement, index) => (
+          <li key={index} className="flex items-start gap-2 text-sm">
+            <span
+              className={`mt-0.5 flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full text-xs transition-all ${
+                requirement.met
+                  ? "bg-emerald-500/20 text-emerald-400"
+                  : "bg-white/5 text-white/30"
+              }`}
+            >
+              {requirement.met ? "✓" : "○"}
+            </span>
+            <span
+              className={`transition-colors ${
+                requirement.met ? "text-emerald-300" : "text-white/50"
+              }`}
+            >
+              {requirement.label}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      {password && !allRequirementsMet && (
+        <p className="text-xs text-orange-300/80">
+          Completa todos los requisitos para continuar
+        </p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Hook para validar si una contraseña cumple con todos los requisitos
+ */
+export function usePasswordValidation(password: string): {
+  isValid: boolean;
+  errors: string[];
+} {
+  return useMemo(() => {
+    const errors: string[] = [];
+
+    if (password.length < 8) {
+      errors.push("La contraseña debe tener al menos 8 caracteres");
+    }
+    if (!/[a-z]/.test(password)) {
+      errors.push("La contraseña debe contener al menos una letra minúscula");
+    }
+    if (!/[A-Z]/.test(password)) {
+      errors.push("La contraseña debe contener al menos una letra mayúscula");
+    }
+    if (!/\d/.test(password)) {
+      errors.push("La contraseña debe contener al menos un número");
+    }
+    if (!/[@$!%*?&]/.test(password)) {
+      errors.push("La contraseña debe contener al menos un carácter especial (@$!%*?&)");
+    }
+
+    return {
+      isValid: errors.length === 0,
+      errors,
+    };
+  }, [password]);
+}

--- a/src/service/authService.ts
+++ b/src/service/authService.ts
@@ -42,8 +42,22 @@ export async function register(dataUser: RegisterPayload): Promise<AuthResponse>
     return data;
   } catch (error: unknown) {
     const axiosError = getAxiosError(error);
-    if (axiosError?.response?.status === 409) {
+    const status = axiosError?.response?.status;
+    const message = (axiosError?.response?.data as { message?: string | string[] })?.message;
+
+    // Mostrar mensaje específico del backend si está disponible
+    if (status === 409) {
       throw new Error("El email ya esta registrado");
+    }
+    if (status === 400) {
+      // Si el backend envía un mensaje específico, úsalo
+      if (message) {
+        if (Array.isArray(message)) {
+          throw new Error(message[0]); // ValidationPipe devuelve array de errores
+        }
+        throw new Error(message);
+      }
+      throw new Error("Los datos proporcionados no son válidos. Revisa los campos.");
     }
 
     throw new Error("Error al registrar usuario");

--- a/src/service/userService.ts
+++ b/src/service/userService.ts
@@ -13,6 +13,7 @@ export interface CreateUserDTO {
   phone?: string;
   role?: UserRole;
   providerType?: ProviderType;
+  profileImage?: string;
 }
 
 export type UserResponse = User;
@@ -24,6 +25,7 @@ export interface UpdateUserDTO {
   phone?: string;
   role?: UserRole;
   providerType?: ProviderType | null;
+  profileImage?: string;
   isActive?: boolean;
   emailVerificationToken?: string;
 }
@@ -35,6 +37,7 @@ export interface UpdateProfileDTO {
   phone?: string;
   role?: UserRole;
   providerType?: ProviderType | null;
+  profileImage?: string;
   isActive?: boolean;
   emailVerificationToken?: string;
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -15,6 +15,7 @@ export interface User {
   phone: string | null;
   role: UserRole;
   providerType: ProviderType | null;
+  profileImage?: string | null;
   isActive: boolean;
   emailVerified: boolean;
   createdAt: string;


### PR DESCRIPTION
- Add profileImage field to User type definition
- Update userService DTOs to include profileImage support
- Create admin page to add/edit provider profile images with base64 upload
- Add image upload component with validation (5MB limit, type checking)
- Display provider profile images in all service/appointment cards:
  * /admin/personal - Staff list with edit functionality
  * /personal-salon - Public provider profiles
  * /reservar - Service selection cards
  * /mis-citas - Appointment listings (upcoming and history)
  * / (homepage) - Featured services
- Add fallback avatars with initials when no image exists
- Improve frontend password validation and error messages
- Fix date handling to use local timezone (avoid day offset issues)